### PR TITLE
Implement node bls

### DIFF
--- a/crates/dkg-cli/src/actions.rs
+++ b/crates/dkg-cli/src/actions.rs
@@ -186,7 +186,7 @@ where
 
     // Instantiate the DKG with the group info
     println!("Calculating and broadcasting our shares...");
-    let phase0 = DKG::new(private_key, group)?;
+    let phase0 = DKG::new(private_key, String::from(""), group)?;
 
     // Run Phase 1 and publish to the chain
     let phase1 = phase0.run(&mut dkg, rand::thread_rng).await?;

--- a/crates/dkg-cli/src/actions.rs
+++ b/crates/dkg-cli/src/actions.rs
@@ -3,7 +3,11 @@ use crate::{
     opts::*,
 };
 use rand::RngCore;
-use std::{fs::File, io::Write, sync::Arc};
+use std::{
+    fs::File,
+    io::{self, Write},
+    sync::Arc,
+};
 
 use dkg_core::{
     primitives::{joint_feldman::*, *},
@@ -256,6 +260,8 @@ async fn wait_for_phase<M: ethers::providers::Middleware>(
             break;
         }
         print!(".");
+        io::stdout().flush().unwrap();
+
         // 6s for 1 Celo block
         tokio::time::delay_for(std::time::Duration::from_millis(6000)).await;
     }

--- a/crates/dkg-core/src/node.rs
+++ b/crates/dkg-core/src/node.rs
@@ -435,7 +435,9 @@ mod tests {
         // Create the Phase 0 for each participant
         let phase0s = keypairs
             .iter()
-            .map(|(private, _)| joint_feldman::DKG::new(private.clone(), group.clone()).unwrap())
+            .map(|(private, _)| {
+                joint_feldman::DKG::new(private.clone(), String::from(""), group.clone()).unwrap()
+            })
             .collect::<Vec<_>>();
 
         // Create the board

--- a/crates/dkg-core/src/primitives/group.rs
+++ b/crates/dkg-core/src/primitives/group.rs
@@ -7,11 +7,11 @@ use threshold_bls::{group::Curve, poly::Idx};
 /// of the protocol, if sucessful, the index is used to verify the validity of
 /// the share this node holds.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-pub struct Node<C: Curve>(Idx, C::Point);
+pub struct Node<C: Curve>(Idx, C::Point, Option<String>);
 
 impl<C: Curve> Node<C> {
     pub fn new(index: Idx, public: C::Point) -> Self {
-        Self(index, public)
+        Self(index, public, None)
     }
 }
 
@@ -24,6 +24,14 @@ impl<C: Curve> Node<C> {
     /// Returns the node's public key
     pub fn key(&self) -> &C::Point {
         &self.1
+    }
+
+    pub fn set_rpc_endpoint(&mut self, rpc_endpoint: String) {
+        self.2 = Some(rpc_endpoint);
+    }
+
+    pub fn get_rpc_endpoint(&self) -> Option<&String> {
+        self.2.as_ref()
     }
 }
 

--- a/crates/dkg-core/src/primitives/resharing.rs
+++ b/crates/dkg-core/src/primitives/resharing.rs
@@ -152,6 +152,7 @@ impl<C: Curve> Phase0<C> for RDKG<C> {
             info.prev_index.unwrap(),
             &secret,
             &public,
+            "",
             &info.new_group,
             rng(),
         )?;
@@ -239,7 +240,7 @@ impl<C: Curve> Phase1<C> for RDKGWaitingShare<C> {
             let secret = info.secret.take().unwrap();
             // we register our own share and publics into the mix
             let didx = info.prev_index.unwrap();
-            shares.insert(didx, secret.eval(didx).value);
+            shares.insert(didx, (secret.eval(didx).value, "".to_string()));
             publics.insert(didx, public.clone());
             // we treat our own share as valid!
             statuses.set(didx, my_idx, Status::Success);
@@ -423,7 +424,7 @@ fn compute_resharing_output<C: Curve>(
     // to compute the final share, we interpolate all the valid shares received
     let mut shares_eval: Vec<Eval<C::Scalar>> = shares
         .into_iter()
-        .map(|(idx, sh)| Eval {
+        .map(|(idx, (sh, _))| Eval {
             value: sh,
             index: idx,
         })
@@ -627,6 +628,7 @@ mod tests {
                 s[target_idx].dealer_idx,
                 &nsecret,
                 &npublic,
+                "",
                 &group,
                 &mut thread_rng(),
             )

--- a/crates/dkg-core/src/primitives/types.rs
+++ b/crates/dkg-core/src/primitives/types.rs
@@ -48,6 +48,8 @@ pub struct EncryptedShare<C: Curve> {
     pub share_idx: Idx,
     /// The ECIES encrypted share
     pub secret: EciesCipher<C>,
+
+    pub rpc_endpoint_secret: EciesCipher<C>,
 }
 
 /// A `BundledResponses` is sent during the second phase of the protocol by all

--- a/crates/randcast-mock-demo/Cargo.toml
+++ b/crates/randcast-mock-demo/Cargo.toml
@@ -10,7 +10,11 @@ path = "src/contract/server.rs"
 
 [[bin]]
 name = "node-client"
-path = "src/client.rs"
+path = "src/node_client.rs"
+
+[[bin]]
+name = "user-client"
+path = "src/user_client.rs"
 
 [dependencies]
 dkg-core = { path = "../dkg-core" }

--- a/crates/randcast-mock-demo/build.rs
+++ b/crates/randcast-mock-demo/build.rs
@@ -1,5 +1,9 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let protos = &["proto/controller.proto", "proto/coordinator.proto"];
+    let protos = &[
+        "proto/controller.proto",
+        "proto/coordinator.proto",
+        "proto/committer.proto",
+    ];
 
     for proto in protos {
         println!("cargo:rerun-if-changed={}", proto);

--- a/crates/randcast-mock-demo/proto/committer.proto
+++ b/crates/randcast-mock-demo/proto/committer.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package committer;
+
+service CommitterService {
+  rpc CommitPartialSignature(CommitPartialSignatureRequest)
+      returns (CommitPartialSignatureReply);
+}
+
+message CommitPartialSignatureRequest {
+  string id_address = 1;
+  uint32 signature_index = 2;
+  bytes partial_signature = 3;
+}
+
+message CommitPartialSignatureReply {
+  bool result = 1;
+}

--- a/crates/randcast-mock-demo/proto/controller.proto
+++ b/crates/randcast-mock-demo/proto/controller.proto
@@ -12,6 +12,12 @@ service Transactions {
   rpc CheckDkgState(CheckDkgStateRequest) returns (google.protobuf.Empty);
 
   rpc Mine(MineRequest) returns (MineReply);
+
+  rpc RequestRandomness(RequestRandomnessRequest)
+      returns (google.protobuf.Empty);
+
+  rpc FulfillRandomness(FulfillRandomnessRequest)
+      returns (google.protobuf.Empty);
 }
 
 message NodeRegisterRequest {
@@ -41,10 +47,29 @@ message MineReply {
   uint32 block_number = 1;
 }
 
+message RequestRandomnessRequest {
+  string message = 1;
+}
+
+message FulfillRandomnessRequest {
+  string id_address = 1;
+  uint32 group_index = 2;
+  uint32 signature_index = 3;
+  bytes signature = 4;
+  map<string, bytes> partial_signatures = 5;
+}
+
 service Views {
   rpc GetGroup(GetGroupRequest) returns (GroupReply);
 
+  rpc GetLastOutput(google.protobuf.Empty) returns (LastOutputReply);
+
   rpc EmitDkgTask(google.protobuf.Empty) returns (DkgTaskReply);
+
+  rpc EmitSignatureTask(google.protobuf.Empty) returns (SignatureTaskReply);
+
+  rpc GetSignatureTaskCompletionState(GetSignatureTaskCompletionStateRequest)
+      returns (GetSignatureTaskCompletionStateReply);
 }
 
 message GetGroupRequest {
@@ -77,4 +102,23 @@ message DkgTaskReply {
   map<string, uint32> members = 5;
   uint32 assignment_block_height = 6;
   string coordinator_address = 7;
+}
+
+message SignatureTaskReply {
+  uint32 index = 1;
+  string message = 2;
+  uint32 group_index = 3;
+  uint32 assignment_block_height = 4;
+}
+
+message LastOutputReply {
+  uint64 last_output = 1;
+}
+
+message GetSignatureTaskCompletionStateRequest {
+  uint32 index = 1;
+}
+
+message GetSignatureTaskCompletionStateReply {
+  bool state = 1;
 }

--- a/crates/randcast-mock-demo/proto/coordinator.proto
+++ b/crates/randcast-mock-demo/proto/coordinator.proto
@@ -5,7 +5,7 @@ import "google/protobuf/empty.proto";
 package coordinator;
 
 service Transactions {
-  rpc publish(PublishRequest) returns (google.protobuf.Empty);
+  rpc Publish(PublishRequest) returns (google.protobuf.Empty);
 }
 
 message PublishRequest {

--- a/crates/randcast-mock-demo/src/client.rs
+++ b/crates/randcast-mock-demo/src/client.rs
@@ -17,9 +17,14 @@ use threshold_bls::sig::Scheme;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     static RNG_FN: fn() -> ThreadRng = rand::thread_rng;
 
-    let args: Vec<String> = env::args().collect();
+    let mut args = env::args();
 
-    let id_address = &args[1];
+    args.next();
+
+    let id_address = match args.next() {
+        Some(arg) => arg,
+        None => panic!("Didn't get a id_address string"),
+    };
 
     println!("id_address: {}", id_address);
 

--- a/crates/randcast-mock-demo/src/contract/coordinator.rs
+++ b/crates/randcast-mock-demo/src/contract/coordinator.rs
@@ -46,7 +46,7 @@ pub trait Transactions {
     fn start(
         &mut self,
         block_height: usize,
-        members: HashMap<String, Vec<u8>>,
+        members: Vec<(String, usize, Vec<u8>)>,
     ) -> CoordinatorResult<()>;
 
     /// Participant publishes their data and depending on the phase the data gets inserted
@@ -120,7 +120,7 @@ impl Transactions for Coordinator {
     fn start(
         &mut self,
         block_height: usize,
-        members: HashMap<String, Vec<u8>>,
+        members: Vec<(String, usize, Vec<u8>)>,
     ) -> CoordinatorResult<()> {
         self.only_when_not_started()?;
 
@@ -128,7 +128,7 @@ impl Transactions for Coordinator {
 
         self.block_height = block_height;
 
-        members.into_iter().for_each(|(address, key)| {
+        members.into_iter().for_each(|(address, _, key)| {
             self.participants.push(address.clone());
 
             self.keys.insert(address, key);
@@ -188,7 +188,11 @@ impl Views for Coordinator {
     }
 
     fn get_bls_keys(&self) -> CoordinatorResult<(usize, Vec<Vec<u8>>)> {
-        let keys = self.keys.values().cloned().collect::<Vec<_>>();
+        let keys = self
+            .participants
+            .iter()
+            .map(|p| self.keys.get(p).unwrap().clone())
+            .collect::<Vec<_>>();
 
         Ok((self.threshold, keys))
     }

--- a/crates/randcast-mock-demo/src/main.rs
+++ b/crates/randcast-mock-demo/src/main.rs
@@ -20,12 +20,14 @@ use threshold_bls::{
 async fn main() -> NodeResult<()> {
     let initial_entropy = 0x8762_4875_6548_6346;
 
+    let controller_address = String::from("test_controller");
+
     println!(
         "controller is deploying... initial entropy: {}",
         initial_entropy
     );
 
-    let mut controller = Controller::new(initial_entropy);
+    let mut controller = Controller::new(initial_entropy, controller_address);
 
     let (t, n) = (3, 5);
 
@@ -98,7 +100,7 @@ async fn main() -> NodeResult<()> {
 
     println!("An user is requesting a randomness... msg seed: {}", msg);
 
-    let request_res = controller.request(&msg);
+    let request_res = controller.request_randomness(&msg);
 
     println!("request_res: {:?}", request_res);
 
@@ -154,7 +156,7 @@ async fn main() -> NodeResult<()> {
         println!(
             "{}-res: {:?}",
             i,
-            controller.fulfill(
+            controller.fulfill_randomness(
                 &format!("0x{}", i),
                 1,
                 signature_index,
@@ -253,7 +255,9 @@ where
     // Create the Phase 0 for each participant
     let phase0s = keypairs
         .iter()
-        .map(|(private, _)| joint_feldman::DKG::new(private.clone(), group.clone()).unwrap())
+        .map(|(private, _)| {
+            joint_feldman::DKG::new(private.clone(), String::from(""), group.clone()).unwrap()
+        })
         .collect::<Vec<_>>();
 
     // Create the board

--- a/crates/randcast-mock-demo/src/node/bls.rs
+++ b/crates/randcast-mock-demo/src/node/bls.rs
@@ -1,0 +1,46 @@
+use super::errors::NodeResult;
+use threshold_bls::{
+    curve::bls12381::{PairingCurve as BLS12_381, Scalar, G1},
+    poly::Poly,
+    sig::{G1Scheme, Share, SignatureScheme, ThresholdScheme},
+};
+
+pub struct MockBLSCore {}
+
+pub trait BLSCore {
+    /// Partially signs a message with a share of the private key
+    fn partial_sign(&self, private: &Share<Scalar>, msg: &[u8]) -> NodeResult<Vec<u8>>;
+
+    /// Verifies a partial signature on a message against the public polynomial
+    fn partial_verify(&self, public: &Poly<G1>, msg: &[u8], partial: &[u8]) -> NodeResult<()>;
+
+    /// Aggregates all partials signature together. Note that this method does
+    /// not verify if the partial signatures are correct or not; it only
+    /// aggregates them.
+    fn aggregate(&self, threshold: usize, partials: &[Vec<u8>]) -> NodeResult<Vec<u8>>;
+
+    /// Verifies that the signature on the provided message was produced by the public key
+    fn verify(&self, public: &G1, msg: &[u8], sig: &[u8]) -> NodeResult<()>;
+}
+
+impl BLSCore for MockBLSCore {
+    fn partial_sign(&self, private: &Share<Scalar>, msg: &[u8]) -> NodeResult<Vec<u8>> {
+        let partial_signature = G1Scheme::<BLS12_381>::partial_sign(private, msg)?;
+        Ok(partial_signature)
+    }
+
+    fn partial_verify(&self, public: &Poly<G1>, msg: &[u8], partial: &[u8]) -> NodeResult<()> {
+        G1Scheme::<BLS12_381>::partial_verify(public, msg, partial)?;
+        Ok(())
+    }
+
+    fn aggregate(&self, threshold: usize, partials: &[Vec<u8>]) -> NodeResult<Vec<u8>> {
+        let signature = G1Scheme::<BLS12_381>::aggregate(threshold, partials)?;
+        Ok(signature)
+    }
+
+    fn verify(&self, public: &G1, msg: &[u8], sig: &[u8]) -> NodeResult<()> {
+        G1Scheme::<BLS12_381>::verify(public, msg, sig)?;
+        Ok(())
+    }
+}

--- a/crates/randcast-mock-demo/src/node/committer_server.rs
+++ b/crates/randcast-mock-demo/src/node/committer_server.rs
@@ -1,0 +1,103 @@
+use futures::Future;
+use parking_lot::RwLock;
+use std::sync::Arc;
+use tonic::{transport::Server, Request, Response, Status};
+
+use self::committer::{
+    committer_service_server::{CommitterService, CommitterServiceServer},
+    CommitPartialSignatureReply, CommitPartialSignatureRequest,
+};
+
+use super::cache::{
+    GroupInfoFetcher, InMemoryGroupInfoCache, InMemorySignatureResultCache,
+    SignatureResultCacheFetcher, SignatureResultCacheUpdater,
+};
+
+pub mod committer {
+    include!("../../stub/committer.rs");
+}
+
+pub struct BLSCommitterServiceServer {
+    group_cache: Arc<RwLock<InMemoryGroupInfoCache>>,
+    committer_cache: Arc<RwLock<InMemorySignatureResultCache>>,
+}
+
+impl BLSCommitterServiceServer {
+    pub fn new(
+        group_cache: Arc<RwLock<InMemoryGroupInfoCache>>,
+        committer_cache: Arc<RwLock<InMemorySignatureResultCache>>,
+    ) -> Self {
+        BLSCommitterServiceServer {
+            group_cache,
+            committer_cache,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl CommitterService for BLSCommitterServiceServer {
+    async fn commit_partial_signature(
+        &self,
+        request: Request<CommitPartialSignatureRequest>,
+    ) -> Result<Response<CommitPartialSignatureReply>, Status> {
+        let req = request.into_inner();
+
+        if !self
+            .committer_cache
+            .read()
+            .contains(req.signature_index as usize)
+        {
+            let group_index = self
+                .group_cache
+                .read()
+                .get_index()
+                .map_err(|e| Status::internal(e.to_string()))?;
+
+            let threshold = self
+                .group_cache
+                .read()
+                .get_threshold()
+                .map_err(|e| Status::internal(e.to_string()))?;
+
+            self.committer_cache
+                .write()
+                .add(group_index, req.signature_index as usize, threshold)
+                .map_err(|e| Status::internal(e.to_string()))?;
+        }
+
+        self.committer_cache
+            .write()
+            .add_partial_signature(
+                req.signature_index as usize,
+                req.id_address,
+                req.partial_signature,
+            )
+            .unwrap();
+
+        Ok(Response::new(CommitPartialSignatureReply { result: true }))
+    }
+}
+
+pub async fn start_committer_server<F: Future<Output = ()>>(
+    endpoint: String,
+    group_cache: Arc<RwLock<InMemoryGroupInfoCache>>,
+    committer_cache: Arc<RwLock<InMemorySignatureResultCache>>,
+    shutdown_signal: F,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let addr = endpoint.parse()?;
+
+    Server::builder()
+        .add_service(CommitterServiceServer::with_interceptor(
+            BLSCommitterServiceServer::new(group_cache, committer_cache),
+            intercept,
+        ))
+        .serve_with_shutdown(addr, shutdown_signal)
+        .await?;
+    Ok(())
+}
+
+fn intercept(req: Request<()>) -> Result<Request<()>, Status> {
+    // println!("Intercepting request: {:?}", req);
+
+    Ok(req)
+}

--- a/crates/randcast-mock-demo/src/node/errors.rs
+++ b/crates/randcast-mock-demo/src/node/errors.rs
@@ -1,4 +1,5 @@
 use thiserror::Error;
+use threshold_bls::sig::{BLSError, G1Scheme, ThresholdError};
 
 use crate::contract::errors::{ControllerError, CoordinatorError};
 use dkg_core::{primitives::DKGError, NodeError as DKGNodeError};
@@ -24,6 +25,12 @@ pub enum NodeError {
 
     #[error(transparent)]
     DKGError(#[from] DKGError),
+
+    #[error(transparent)]
+    BLSError(#[from] BLSError),
+
+    #[error(transparent)]
+    ThresholdError(#[from] ThresholdError<G1Scheme<threshold_bls::curve::bls12381::PairingCurve>>),
 
     #[error(transparent)]
     RpcClientError(#[from] tonic::transport::Error),
@@ -54,4 +61,10 @@ pub enum NodeError {
 
     #[error("the group is still waiting for other's DKGOutput to commit")]
     GroupWaitingForConsensus,
+
+    #[error("there is no signature cache yet")]
+    CommitterCacheNotExisted,
+
+    #[error("there is no task yet")]
+    NoTaskAvailable,
 }

--- a/crates/randcast-mock-demo/src/node/mod.rs
+++ b/crates/randcast-mock-demo/src/node/mod.rs
@@ -6,6 +6,10 @@ pub mod types;
 
 pub mod dkg;
 
+pub mod bls;
+
 pub mod client;
 
 pub mod monitor;
+
+pub mod committer_server;

--- a/crates/randcast-mock-demo/src/node/monitor.rs
+++ b/crates/randcast-mock-demo/src/node/monitor.rs
@@ -563,6 +563,7 @@ impl BLSTaskListener for MockBLSTaskListener {
                     break;
                 }
                 i += 1;
+                tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
             }
         }
 

--- a/crates/randcast-mock-demo/src/node/monitor.rs
+++ b/crates/randcast-mock-demo/src/node/monitor.rs
@@ -15,6 +15,7 @@ use async_trait::async_trait;
 use futures::TryFutureExt;
 use parking_lot::RwLock;
 use rand::RngCore;
+use std::io::{self, Write};
 use std::sync::Arc;
 
 pub const DEFAULT_DKG_TIMEOUT_DURATION: usize = 30 * 3;
@@ -127,6 +128,7 @@ impl<F: Fn() -> R + Send + Sync + Copy + 'static, R: RngCore + 'static>
                 }
             }
             print!(".");
+            io::stdout().flush().unwrap();
 
             tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
         }

--- a/crates/randcast-mock-demo/src/node/monitor.rs
+++ b/crates/randcast-mock-demo/src/node/monitor.rs
@@ -1,10 +1,18 @@
-use super::cache::{BlockInfoFetcher, BlockInfoUpdater, GroupInfoFetcher, GroupInfoUpdater};
+use crate::node::cache::{BLSTasksFetcher, BLSTasksUpdater, SignatureResultCacheFetcher};
+use crate::node::committer_server;
+
+use super::cache::{
+    BlockInfoFetcher, BlockInfoUpdater, GroupInfoFetcher, GroupInfoUpdater, InMemoryBLSTasksQueue,
+    InMemorySignatureResultCache, SignatureResultCache, SignatureResultCacheUpdater,
+};
 use super::client::{
-    ControllerMockHelper, ControllerTransactions, ControllerViews, MockControllerClient,
+    CommitterService, ControllerMockHelper, ControllerTransactions, ControllerViews,
+    MockCommitterClient, MockControllerClient, MockCoordinatorClient,
 };
 use super::errors::{NodeError, NodeResult};
-use super::types::Group;
+use super::types::{Group, SignatureTask};
 use super::{
+    bls::{BLSCore, MockBLSCore},
     cache::{
         InMemoryBlockInfoCache, InMemoryGroupInfoCache, InMemoryNodeInfoCache, NodeInfoFetcher,
     },
@@ -12,25 +20,19 @@ use super::{
     types::DKGTask,
 };
 use async_trait::async_trait;
-use futures::TryFutureExt;
 use parking_lot::RwLock;
 use rand::RngCore;
 use std::io::{self, Write};
 use std::sync::Arc;
+use tokio::task::JoinHandle;
 
 pub const DEFAULT_DKG_TIMEOUT_DURATION: usize = 30 * 3;
 
 #[async_trait]
 pub trait StartingGroupingListener<F, R> {
-    async fn start(&self) -> NodeResult<()>;
+    async fn start(self) -> NodeResult<()>;
 
-    async fn handle(
-        task: DKGTask,
-        rng: F,
-        node_cache: Arc<RwLock<impl NodeInfoFetcher + Send + Sync + 'async_trait>>,
-        group_cache_fetcher: Arc<RwLock<impl GroupInfoFetcher + Send + Sync + 'async_trait>>,
-        group_cache_updater: Arc<RwLock<impl GroupInfoUpdater + Send + Sync + 'async_trait>>,
-    ) -> NodeResult<usize>
+    async fn handle(&self, task: DKGTask) -> NodeResult<usize>
     where
         R: RngCore,
         F: Fn() -> R + 'static;
@@ -41,6 +43,8 @@ pub struct MockStartingGroupingListener<F: Fn() -> R, R: RngCore> {
     block_cache: Arc<RwLock<InMemoryBlockInfoCache>>,
     node_cache: Arc<RwLock<InMemoryNodeInfoCache>>,
     group_cache: Arc<RwLock<InMemoryGroupInfoCache>>,
+    bls_tasks_cache: Arc<RwLock<InMemoryBLSTasksQueue>>,
+    committer_cache: Arc<RwLock<InMemorySignatureResultCache>>,
 }
 
 impl<F: Fn() -> R, R: RngCore> MockStartingGroupingListener<F, R> {
@@ -49,12 +53,16 @@ impl<F: Fn() -> R, R: RngCore> MockStartingGroupingListener<F, R> {
         block_cache: Arc<RwLock<InMemoryBlockInfoCache>>,
         node_cache: Arc<RwLock<InMemoryNodeInfoCache>>,
         group_cache: Arc<RwLock<InMemoryGroupInfoCache>>,
+        bls_tasks_cache: Arc<RwLock<InMemoryBLSTasksQueue>>,
+        committer_cache: Arc<RwLock<InMemorySignatureResultCache>>,
     ) -> Self {
         MockStartingGroupingListener {
             rng,
             block_cache,
             node_cache,
             group_cache,
+            bls_tasks_cache,
+            committer_cache,
         }
     }
 }
@@ -63,12 +71,17 @@ impl<F: Fn() -> R, R: RngCore> MockStartingGroupingListener<F, R> {
 impl<F: Fn() -> R + Send + Sync + Copy + 'static, R: RngCore + 'static>
     StartingGroupingListener<F, R> for MockStartingGroupingListener<F, R>
 {
-    async fn start(&self) -> NodeResult<()> {
-        let controller_address = String::from("http://[::1]:50052");
-
+    async fn start(self) -> NodeResult<()> {
         let id_address = self.node_cache.read().get_id_address().to_string();
 
-        let mut client = MockControllerClient::new(controller_address, id_address).await?;
+        let controller_address = self
+            .node_cache
+            .read()
+            .get_controller_rpc_endpoint()
+            .to_string();
+
+        let mut client =
+            MockControllerClient::new(controller_address.clone(), id_address.clone()).await?;
 
         loop {
             if let Ok(dkg_task) = client.emit_dkg_task().await {
@@ -95,35 +108,44 @@ impl<F: Fn() -> R + Send + Sync + Copy + 'static, R: RngCore + 'static>
                             task_group_index, task_epoch
                         );
 
-                        let block_cache = self.block_cache.clone();
+                        let id_address = id_address.clone();
 
-                        let node_cache = self.node_cache.clone();
+                        let controller_address = controller_address.clone();
+
+                        let node_rpc_endpoint =
+                            self.node_cache.read().get_node_rpc_endpoint().to_string();
+
+                        let block_cache = self.block_cache.clone();
 
                         let group_cache = self.group_cache.clone();
 
-                        let rng = self.rng;
+                        let bls_tasks_cache = self.bls_tasks_cache.clone();
 
-                        tokio::spawn(async move {
-                            if let Err(e) = MockStartingGroupingListener::handle(
-                                dkg_task,
-                                rng,
-                                node_cache.clone(),
-                                group_cache.clone(),
-                                group_cache.clone(),
-                            )
-                            .and_then(move |timeout_block_height| {
-                                let end_grouping_listener = MockEndGroupingListener::new(
-                                    block_cache.clone(),
-                                    node_cache,
-                                    group_cache,
-                                );
-                                end_grouping_listener.start(timeout_block_height)
-                            })
-                            .await
-                            {
+                        let committer_cache = self.committer_cache.clone();
+
+                        match self.handle(dkg_task).await {
+                            Ok(timeout_block_height) => {
+                                tokio::spawn(async move {
+                                    let end_grouping_listener = MockEndGroupingListener::new(
+                                        id_address,
+                                        controller_address,
+                                        node_rpc_endpoint,
+                                        block_cache,
+                                        group_cache,
+                                        bls_tasks_cache,
+                                        committer_cache,
+                                    );
+                                    if let Err(e) =
+                                        end_grouping_listener.start(timeout_block_height).await
+                                    {
+                                        println!("{:?}", e);
+                                    }
+                                });
+                            }
+                            Err(e) => {
                                 println!("{:?}", e);
                             }
-                        });
+                        }
                     }
                 }
             }
@@ -134,29 +156,35 @@ impl<F: Fn() -> R + Send + Sync + Copy + 'static, R: RngCore + 'static>
         }
     }
 
-    async fn handle(
-        task: DKGTask,
-        rng: F,
-        node_cache: Arc<RwLock<impl NodeInfoFetcher + Send + Sync + 'async_trait>>,
-        group_cache_fetcher: Arc<RwLock<impl GroupInfoFetcher + Send + Sync + 'async_trait>>,
-        group_cache_updater: Arc<RwLock<impl GroupInfoUpdater + Send + Sync + 'async_trait>>,
-    ) -> NodeResult<usize>
+    async fn handle(&self, task: DKGTask) -> NodeResult<usize>
     where
         R: RngCore,
         F: Fn() -> R + Send + 'async_trait,
     {
-        let controller_address = String::from("http://[::1]:50052");
+        let controller_address = self
+            .node_cache
+            .read()
+            .get_controller_rpc_endpoint()
+            .to_string();
 
-        let id_address = node_cache.read().get_id_address().to_string();
+        let coordinator_rpc_endpoint = self
+            .node_cache
+            .read()
+            .get_controller_rpc_endpoint()
+            .to_string();
+
+        let id_address = self.node_cache.read().get_id_address().to_string();
+
+        let node_rpc_endpoint = self.node_cache.read().get_node_rpc_endpoint().to_string();
 
         let mut controller_client =
             MockControllerClient::new(controller_address, id_address).await?;
 
         let mut dkg_core = MockDKGCore {};
 
-        let dkg_private_key = *node_cache.read().get_dkg_private_key()?;
+        let dkg_private_key = *self.node_cache.read().get_dkg_private_key()?;
 
-        let id_address = node_cache.read().get_id_address().to_string();
+        let id_address = self.node_cache.read().get_id_address().to_string();
 
         let task_group_index = task.group_index;
 
@@ -164,12 +192,30 @@ impl<F: Fn() -> R + Send + Sync + Copy + 'static, R: RngCore + 'static>
 
         let timeout_block_height = task.assignment_block_height + DEFAULT_DKG_TIMEOUT_DURATION;
 
+        let group_cache_fetcher = self.group_cache.clone();
+
         //TODO retry if error happens
+        let coordinator_client = MockCoordinatorClient::new(
+            coordinator_rpc_endpoint,
+            id_address,
+            task.group_index,
+            task.epoch,
+        )
+        .await?;
+
         let output = dkg_core
-            .run_dkg(dkg_private_key, id_address, task, rng, group_cache_fetcher)
+            .run_dkg(
+                dkg_private_key,
+                node_rpc_endpoint,
+                task,
+                self.rng,
+                coordinator_client,
+                group_cache_fetcher,
+            )
             .await?;
 
-        let (public_key, partial_public_key, disqualified_nodes) = group_cache_updater
+        let (public_key, partial_public_key, disqualified_nodes) = self
+            .group_cache
             .write()
             .save_output(task_group_index, task_epoch, output)?;
 
@@ -195,21 +241,33 @@ trait EndGroupingListener {
 }
 
 pub struct MockEndGroupingListener {
+    id_address: String,
+    controller_address: String,
+    node_rpc_endpoint: String,
     block_cache: Arc<RwLock<InMemoryBlockInfoCache>>,
-    node_cache: Arc<RwLock<InMemoryNodeInfoCache>>,
     group_cache: Arc<RwLock<InMemoryGroupInfoCache>>,
+    bls_tasks_cache: Arc<RwLock<InMemoryBLSTasksQueue>>,
+    committer_cache: Arc<RwLock<InMemorySignatureResultCache>>,
 }
 
 impl MockEndGroupingListener {
     pub fn new(
+        id_address: String,
+        controller_address: String,
+        node_rpc_endpoint: String,
         block_cache: Arc<RwLock<InMemoryBlockInfoCache>>,
-        node_cache: Arc<RwLock<InMemoryNodeInfoCache>>,
         group_cache: Arc<RwLock<InMemoryGroupInfoCache>>,
+        bls_tasks_cache: Arc<RwLock<InMemoryBLSTasksQueue>>,
+        committer_cache: Arc<RwLock<InMemorySignatureResultCache>>,
     ) -> Self {
         MockEndGroupingListener {
+            id_address,
+            controller_address,
+            node_rpc_endpoint,
             block_cache,
-            node_cache,
             group_cache,
+            bls_tasks_cache,
+            committer_cache,
         }
     }
 }
@@ -217,11 +275,9 @@ impl MockEndGroupingListener {
 #[async_trait]
 impl EndGroupingListener for MockEndGroupingListener {
     async fn start(self, timeout_block_height: usize) -> NodeResult<()> {
-        let controller_address = String::from("http://[::1]:50052");
-
-        let id_address = self.node_cache.read().get_id_address().to_string();
-
-        let mut client = MockControllerClient::new(controller_address, id_address).await?;
+        let mut client =
+            MockControllerClient::new(self.controller_address.clone(), self.id_address.clone())
+                .await?;
 
         let group_index = self.group_cache.read().get_index()?;
 
@@ -230,7 +286,114 @@ impl EndGroupingListener for MockEndGroupingListener {
 
             match self.handle(group) {
                 Ok(()) => {
-                    println!("DKG task execute successfully! Ready to handle bls task.");
+                    println!("DKG task execute successfully!");
+
+                    let mut listener_tasks: Vec<JoinHandle<()>> = Vec::new();
+
+                    if self.group_cache.read().is_committer(&self.id_address)? {
+                        let id_address = self.id_address.clone();
+
+                        let controller_address = self.controller_address.clone();
+
+                        let committer_cache = self.committer_cache.clone();
+
+                        let signature_aggregation_listener_task = tokio::spawn(async move {
+                            let signature_aggregation_listener =
+                                MockSignatureAggregationListener::new(
+                                    id_address,
+                                    controller_address,
+                                    committer_cache,
+                                );
+                            if let Err(e) = signature_aggregation_listener.start().await {
+                                println!("{:?}", e);
+                            }
+                        });
+
+                        listener_tasks.push(signature_aggregation_listener_task);
+
+                        let group_cache = self.group_cache.clone();
+                        let endpoint = self.node_rpc_endpoint.clone();
+                        let group_cache_for_committer_server = self.group_cache.clone();
+                        let committer_cache_for_committer_server = self.committer_cache.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = committer_server::start_committer_server(
+                                endpoint,
+                                group_cache_for_committer_server,
+                                committer_cache_for_committer_server,
+                                async {
+                                    loop {
+                                        match group_cache.clone().read().get_state() {
+                                            Err(_) => {
+                                                break;
+                                            }
+                                            Ok(false) => {
+                                                break;
+                                            }
+                                            _ => {}
+                                        }
+                                        tokio::time::sleep(std::time::Duration::from_millis(2000))
+                                            .await;
+                                    }
+                                },
+                            )
+                            .await
+                            {
+                                println!("{:?}", e);
+                            };
+                        });
+                    }
+
+                    let id_address = self.id_address.clone();
+
+                    let controller_address = self.controller_address.clone();
+
+                    let block_cache = self.block_cache.clone();
+
+                    let group_cache = self.group_cache.clone();
+
+                    let bls_tasks_cache = self.bls_tasks_cache.clone();
+
+                    let committer_cache = self.committer_cache.clone();
+
+                    let bls_task_listener_task = tokio::spawn(async move {
+                        let mut bls_task_listener = MockBLSTaskListener::new(
+                            id_address,
+                            controller_address,
+                            block_cache,
+                            group_cache,
+                            bls_tasks_cache,
+                            committer_cache,
+                        );
+                        if let Err(e) = bls_task_listener.init().await {
+                            println!("{:?}", e);
+                        }
+                        if let Err(e) = bls_task_listener.start().await {
+                            println!("{:?}", e);
+                        }
+                    });
+
+                    listener_tasks.push(bls_task_listener_task);
+
+                    let group_cache = self.group_cache.clone();
+                    tokio::spawn(async move {
+                        loop {
+                            match group_cache.clone().read().get_state() {
+                                Err(_) => {
+                                    for task in listener_tasks {
+                                        task.abort();
+                                    }
+                                    break;
+                                }
+                                Ok(false) => {
+                                    for task in listener_tasks {
+                                        task.abort();
+                                    }
+                                    break;
+                                }
+                                _ => {}
+                            }
+                        }
+                    });
 
                     return Ok(());
                 }
@@ -271,27 +434,33 @@ impl EndGroupingListener for MockEndGroupingListener {
 
 #[async_trait]
 pub trait BlockListener {
-    async fn start(&self) -> NodeResult<()>;
+    async fn start(self) -> NodeResult<()>;
 
     fn handle(&self, block_height: usize) -> NodeResult<()>;
 }
 
 pub struct MockBlockListener {
-    node_cache: Arc<RwLock<InMemoryBlockInfoCache>>,
+    controller_address: String,
+    block_cache: Arc<RwLock<InMemoryBlockInfoCache>>,
 }
 
 impl MockBlockListener {
-    pub fn new(node_cache: Arc<RwLock<InMemoryBlockInfoCache>>) -> Self {
-        MockBlockListener { node_cache }
+    pub fn new(
+        controller_address: String,
+        node_cache: Arc<RwLock<InMemoryBlockInfoCache>>,
+    ) -> Self {
+        MockBlockListener {
+            controller_address,
+            block_cache: node_cache,
+        }
     }
 }
 
 #[async_trait]
 impl BlockListener for MockBlockListener {
-    async fn start(&self) -> NodeResult<()> {
-        let controller_address = String::from("http://[::1]:50052");
-
-        let mut client = MockControllerClient::new(controller_address, "".to_string()).await?;
+    async fn start(self) -> NodeResult<()> {
+        let mut client =
+            MockControllerClient::new(self.controller_address.clone(), "".to_string()).await?;
 
         loop {
             let block_height = client.mine(1).await?;
@@ -303,8 +472,282 @@ impl BlockListener for MockBlockListener {
     }
 
     fn handle(&self, block_height: usize) -> NodeResult<()> {
-        self.node_cache.write().set_block_height(block_height);
+        self.block_cache.write().set_block_height(block_height);
 
         Ok(())
+    }
+}
+
+#[async_trait]
+pub trait BLSTaskListener {
+    async fn init(&mut self) -> NodeResult<()>;
+
+    async fn start(mut self) -> NodeResult<()>;
+
+    fn handle(
+        &self,
+        task: &SignatureTask,
+        group_cache_fetcher: Arc<RwLock<impl GroupInfoFetcher + Send + Sync>>,
+    ) -> NodeResult<Vec<u8>>;
+}
+
+pub struct MockBLSTaskListener {
+    id_address: String,
+    controller_address: String,
+    block_cache: Arc<RwLock<InMemoryBlockInfoCache>>,
+    group_cache: Arc<RwLock<InMemoryGroupInfoCache>>,
+    bls_tasks_cache: Arc<RwLock<InMemoryBLSTasksQueue>>,
+    committer_cache: Arc<RwLock<InMemorySignatureResultCache>>,
+    committer_clients: Vec<MockCommitterClient>,
+}
+
+impl MockBLSTaskListener {
+    pub fn new(
+        id_address: String,
+        controller_address: String,
+        block_cache: Arc<RwLock<InMemoryBlockInfoCache>>,
+        group_cache: Arc<RwLock<InMemoryGroupInfoCache>>,
+        bls_tasks_cache: Arc<RwLock<InMemoryBLSTasksQueue>>,
+        committer_cache: Arc<RwLock<InMemorySignatureResultCache>>,
+    ) -> Self {
+        MockBLSTaskListener {
+            id_address,
+            controller_address,
+            block_cache,
+            group_cache,
+            bls_tasks_cache,
+            committer_cache,
+            committer_clients: Vec::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl BLSTaskListener for MockBLSTaskListener {
+    async fn init(&mut self) -> NodeResult<()> {
+        let state = self.group_cache.read().get_state()?;
+
+        if !state {
+            return Err(NodeError::GroupNotReady);
+        }
+
+        println!("ready to handle bls task.");
+
+        let mut committers = self
+            .group_cache
+            .read()
+            .get_committers()?
+            .iter()
+            .map(|c| c.to_string())
+            .collect::<Vec<_>>();
+
+        committers.retain(|c| *c != self.id_address);
+
+        for committer in committers {
+            let endpoint = self
+                .group_cache
+                .read()
+                .get_member(&committer)?
+                .rpc_endpint
+                .as_ref()
+                .unwrap()
+                .to_string();
+
+            // we retry some times here as building tonic connection needs the target rpc server available
+            let mut i = 0;
+            while i < 3 {
+                if let Ok(committer_client) =
+                    MockCommitterClient::new(self.id_address.clone(), endpoint.clone()).await
+                {
+                    self.committer_clients.push(committer_client);
+                    break;
+                }
+                i += 1;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn start(mut self) -> NodeResult<()> {
+        let mut client =
+            MockControllerClient::new(self.controller_address.clone(), self.id_address.clone())
+                .await?;
+
+        loop {
+            let task_reply = client.emit_signature_task().await;
+
+            if let Err(NodeError::NoTaskAvailable) = task_reply {
+                tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
+                continue;
+            }
+
+            let task = task_reply.unwrap();
+
+            let SignatureTask {
+                index: task_index,
+                message: task_message,
+                group_index: _,
+                assignment_block_height: _,
+            } = task.clone();
+
+            if self.bls_tasks_cache.read().contains(task_index) {
+                tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
+                continue;
+            }
+
+            println!(
+                "received new signature task. index: {}, message: {}",
+                task_index, task_message
+            );
+
+            self.bls_tasks_cache.write().add(task.clone())?;
+
+            let current_group_index = self.group_cache.read().get_index()?;
+
+            let current_block_height = self.block_cache.read().get_block_height();
+
+            let available_tasks = self
+                .bls_tasks_cache
+                .write()
+                .check_and_get_available_tasks(current_block_height, current_group_index);
+
+            let group_cache = self.group_cache.clone();
+
+            for task in available_tasks {
+                match self.handle(&task, group_cache.clone()) {
+                    Ok(partial_signature) => {
+                        let threshold = self.group_cache.read().get_threshold()?;
+
+                        if self.group_cache.read().is_committer(&self.id_address)? {
+                            if !self.committer_cache.read().contains(task_index) {
+                                self.committer_cache.write().add(
+                                    current_group_index,
+                                    task_index,
+                                    threshold,
+                                )?;
+                            }
+
+                            self.committer_cache.write().add_partial_signature(
+                                task_index,
+                                self.id_address.clone(),
+                                partial_signature.clone(),
+                            )?;
+                        }
+
+                        for committer in self.committer_clients.iter_mut() {
+                            committer
+                                .commit_partial_signature(task_index, partial_signature.clone())
+                                .await?;
+                        }
+                    }
+
+                    Err(e) => {
+                        println!("{:?}", e);
+                    }
+                }
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+        }
+    }
+
+    fn handle(
+        &self,
+        task: &SignatureTask,
+        group_cache_fetcher: Arc<RwLock<impl GroupInfoFetcher + Send + Sync>>,
+    ) -> NodeResult<Vec<u8>> {
+        let fetcher = group_cache_fetcher.read();
+
+        let share = fetcher.get_secret_share()?;
+
+        let bls_core = MockBLSCore {};
+
+        let partial_signature = bls_core.partial_sign(share, task.message.as_bytes())?;
+
+        Ok(partial_signature)
+    }
+}
+
+#[async_trait]
+pub trait SignatureAggregationListener {
+    async fn start(self) -> NodeResult<()>;
+}
+
+pub struct MockSignatureAggregationListener {
+    id_address: String,
+    controller_address: String,
+    committer_cache: Arc<RwLock<InMemorySignatureResultCache>>,
+}
+
+impl MockSignatureAggregationListener {
+    pub fn new(
+        id_address: String,
+        controller_address: String,
+        committer_cache: Arc<RwLock<InMemorySignatureResultCache>>,
+    ) -> Self {
+        MockSignatureAggregationListener {
+            id_address,
+            controller_address,
+            committer_cache,
+        }
+    }
+}
+
+#[async_trait]
+impl SignatureAggregationListener for MockSignatureAggregationListener {
+    async fn start(self) -> NodeResult<()> {
+        let mut client =
+            MockControllerClient::new(self.controller_address, self.id_address).await?;
+
+        loop {
+            let ready_signatures = self
+                .committer_cache
+                .write()
+                .get_ready_to_commit_signatures();
+
+            for signature in ready_signatures {
+                let SignatureResultCache {
+                    group_index,
+                    signature_index,
+                    threshold,
+                    partial_signatures,
+                } = signature;
+
+                let bls_core = MockBLSCore {};
+
+                let signature = bls_core.aggregate(
+                    threshold,
+                    &partial_signatures.values().cloned().collect::<Vec<_>>(),
+                )?;
+
+                if !client
+                    .get_signature_task_completion_state(signature_index)
+                    .await?
+                {
+                    match client
+                        .fulfill_randomness(
+                            group_index,
+                            signature_index,
+                            signature.clone(),
+                            partial_signatures,
+                        )
+                        .await
+                    {
+                        Ok(()) => {
+                            println!("fulfill randomness successfully! signature index: {}, group_index: {}, signature: {}",
+                            signature_index, group_index, hex::encode(signature));
+                        }
+                        Err(e) => {
+                            println!("{:?}", e);
+                        }
+                    }
+                }
+
+                self.committer_cache.write().remove(signature_index)?;
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
+        }
     }
 }

--- a/crates/randcast-mock-demo/src/node/types.rs
+++ b/crates/randcast-mock-demo/src/node/types.rs
@@ -51,5 +51,6 @@ impl Group {
 pub struct Member {
     pub index: usize,
     pub id_address: String,
+    pub rpc_endpint: Option<String>,
     pub partial_public_key: Option<G1>,
 }

--- a/crates/randcast-mock-demo/src/user_client.rs
+++ b/crates/randcast-mock-demo/src/user_client.rs
@@ -1,0 +1,39 @@
+use randcast_mock_demo::node::client::MockControllerClient;
+use randcast_mock_demo::node::client::{ControllerTransactions, ControllerViews};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = env::args();
+
+    args.next();
+
+    let id_address = match args.next() {
+        Some(arg) => arg,
+        None => panic!("Didn't get an id_address string"),
+    };
+
+    let controller_rpc_endpoint = match args.next() {
+        Some(arg) => arg,
+        None => panic!("Didn't get a controller rpc endpoint string"),
+    };
+
+    let instruction = match args.next() {
+        Some(arg) => arg,
+        None => panic!("Didn't get in instruction string"),
+    };
+
+    let mut client = MockControllerClient::new(controller_rpc_endpoint, id_address).await?;
+
+    if instruction == "request" {
+        client.request_randomness("asdasdas").await?;
+
+        println!("request randomness successfully");
+    } else if instruction == "last_output" {
+        let res = client.get_last_output().await?;
+
+        println!("last_randomness_output: {}", res);
+    }
+
+    Ok(())
+}

--- a/crates/randcast-mock-demo/stub/committer.rs
+++ b/crates/randcast-mock-demo/stub/committer.rs
@@ -1,0 +1,213 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CommitPartialSignatureRequest {
+    #[prost(string, tag = "1")]
+    pub id_address: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "2")]
+    pub signature_index: u32,
+    #[prost(bytes = "vec", tag = "3")]
+    pub partial_signature: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CommitPartialSignatureReply {
+    #[prost(bool, tag = "1")]
+    pub result: bool,
+}
+#[doc = r" Generated client implementations."]
+pub mod committer_service_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[derive(Debug, Clone)]
+    pub struct CommitterServiceClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl CommitterServiceClient<tonic::transport::Channel> {
+        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> CommitterServiceClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::ResponseBody: Body + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> CommitterServiceClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
+        {
+            CommitterServiceClient::new(InterceptedService::new(inner, interceptor))
+        }
+        #[doc = r" Compress requests with `gzip`."]
+        #[doc = r""]
+        #[doc = r" This requires the server to support it otherwise it might respond with an"]
+        #[doc = r" error."]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        #[doc = r" Enable decompressing responses with `gzip`."]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        pub async fn commit_partial_signature(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CommitPartialSignatureRequest>,
+        ) -> Result<tonic::Response<super::CommitPartialSignatureReply>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/committer.CommitterService/CommitPartialSignature",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
+#[doc = r" Generated server implementations."]
+pub mod committer_service_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    #[doc = "Generated trait containing gRPC methods that should be implemented for use with CommitterServiceServer."]
+    #[async_trait]
+    pub trait CommitterService: Send + Sync + 'static {
+        async fn commit_partial_signature(
+            &self,
+            request: tonic::Request<super::CommitPartialSignatureRequest>,
+        ) -> Result<tonic::Response<super::CommitPartialSignatureReply>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct CommitterServiceServer<T: CommitterService> {
+        inner: _Inner<T>,
+        accept_compression_encodings: (),
+        send_compression_encodings: (),
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: CommitterService> CommitterServiceServer<T> {
+        pub fn new(inner: T) -> Self {
+            let inner = Arc::new(inner);
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for CommitterServiceServer<T>
+    where
+        T: CommitterService,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = Never;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/committer.CommitterService/CommitPartialSignature" => {
+                    #[allow(non_camel_case_types)]
+                    struct CommitPartialSignatureSvc<T: CommitterService>(pub Arc<T>);
+                    impl<T: CommitterService>
+                        tonic::server::UnaryService<super::CommitPartialSignatureRequest>
+                        for CommitPartialSignatureSvc<T>
+                    {
+                        type Response = super::CommitPartialSignatureReply;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::CommitPartialSignatureRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut =
+                                async move { (*inner).commit_partial_signature(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CommitPartialSignatureSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+    impl<T: CommitterService> Clone for CommitterServiceServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: CommitterService> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: CommitterService> tonic::transport::NamedService for CommitterServiceServer<T> {
+        const NAME: &'static str = "committer.CommitterService";
+    }
+}

--- a/crates/randcast-mock-demo/stub/controller.rs
+++ b/crates/randcast-mock-demo/stub/controller.rs
@@ -38,6 +38,25 @@ pub struct MineReply {
     pub block_number: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RequestRandomnessRequest {
+    #[prost(string, tag = "1")]
+    pub message: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FulfillRandomnessRequest {
+    #[prost(string, tag = "1")]
+    pub id_address: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "2")]
+    pub group_index: u32,
+    #[prost(uint32, tag = "3")]
+    pub signature_index: u32,
+    #[prost(bytes = "vec", tag = "4")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
+    #[prost(map = "string, bytes", tag = "5")]
+    pub partial_signatures:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::vec::Vec<u8>>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetGroupRequest {
     #[prost(uint32, tag = "1")]
     pub index: u32,
@@ -88,6 +107,32 @@ pub struct DkgTaskReply {
     pub assignment_block_height: u32,
     #[prost(string, tag = "7")]
     pub coordinator_address: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SignatureTaskReply {
+    #[prost(uint32, tag = "1")]
+    pub index: u32,
+    #[prost(string, tag = "2")]
+    pub message: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "3")]
+    pub group_index: u32,
+    #[prost(uint32, tag = "4")]
+    pub assignment_block_height: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LastOutputReply {
+    #[prost(uint64, tag = "1")]
+    pub last_output: u64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetSignatureTaskCompletionStateRequest {
+    #[prost(uint32, tag = "1")]
+    pub index: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetSignatureTaskCompletionStateReply {
+    #[prost(bool, tag = "1")]
+    pub state: bool,
 }
 #[doc = r" Generated client implementations."]
 pub mod transactions_client {
@@ -207,6 +252,36 @@ pub mod transactions_client {
             let path = http::uri::PathAndQuery::from_static("/controller.Transactions/Mine");
             self.inner.unary(request.into_request(), path, codec).await
         }
+        pub async fn request_randomness(
+            &mut self,
+            request: impl tonic::IntoRequest<super::RequestRandomnessRequest>,
+        ) -> Result<tonic::Response<()>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/controller.Transactions/RequestRandomness");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn fulfill_randomness(
+            &mut self,
+            request: impl tonic::IntoRequest<super::FulfillRandomnessRequest>,
+        ) -> Result<tonic::Response<()>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/controller.Transactions/FulfillRandomness");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
     }
 }
 #[doc = r" Generated client implementations."]
@@ -283,6 +358,20 @@ pub mod views_client {
             let path = http::uri::PathAndQuery::from_static("/controller.Views/GetGroup");
             self.inner.unary(request.into_request(), path, codec).await
         }
+        pub async fn get_last_output(
+            &mut self,
+            request: impl tonic::IntoRequest<()>,
+        ) -> Result<tonic::Response<super::LastOutputReply>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/controller.Views/GetLastOutput");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
         pub async fn emit_dkg_task(
             &mut self,
             request: impl tonic::IntoRequest<()>,
@@ -295,6 +384,37 @@ pub mod views_client {
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/controller.Views/EmitDkgTask");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn emit_signature_task(
+            &mut self,
+            request: impl tonic::IntoRequest<()>,
+        ) -> Result<tonic::Response<super::SignatureTaskReply>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/controller.Views/EmitSignatureTask");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn get_signature_task_completion_state(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetSignatureTaskCompletionStateRequest>,
+        ) -> Result<tonic::Response<super::GetSignatureTaskCompletionStateReply>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/controller.Views/GetSignatureTaskCompletionState",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
@@ -322,6 +442,14 @@ pub mod transactions_server {
             &self,
             request: tonic::Request<super::MineRequest>,
         ) -> Result<tonic::Response<super::MineReply>, tonic::Status>;
+        async fn request_randomness(
+            &self,
+            request: tonic::Request<super::RequestRandomnessRequest>,
+        ) -> Result<tonic::Response<()>, tonic::Status>;
+        async fn fulfill_randomness(
+            &self,
+            request: tonic::Request<super::FulfillRandomnessRequest>,
+        ) -> Result<tonic::Response<()>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct TransactionsServer<T: Transactions> {
@@ -490,6 +618,74 @@ pub mod transactions_server {
                     };
                     Box::pin(fut)
                 }
+                "/controller.Transactions/RequestRandomness" => {
+                    #[allow(non_camel_case_types)]
+                    struct RequestRandomnessSvc<T: Transactions>(pub Arc<T>);
+                    impl<T: Transactions>
+                        tonic::server::UnaryService<super::RequestRandomnessRequest>
+                        for RequestRandomnessSvc<T>
+                    {
+                        type Response = ();
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RequestRandomnessRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).request_randomness(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = RequestRandomnessSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/controller.Transactions/FulfillRandomness" => {
+                    #[allow(non_camel_case_types)]
+                    struct FulfillRandomnessSvc<T: Transactions>(pub Arc<T>);
+                    impl<T: Transactions>
+                        tonic::server::UnaryService<super::FulfillRandomnessRequest>
+                        for FulfillRandomnessSvc<T>
+                    {
+                        type Response = ();
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::FulfillRandomnessRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).fulfill_randomness(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = FulfillRandomnessSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 _ => Box::pin(async move {
                     Ok(http::Response::builder()
                         .status(200)
@@ -536,10 +732,22 @@ pub mod views_server {
             &self,
             request: tonic::Request<super::GetGroupRequest>,
         ) -> Result<tonic::Response<super::GroupReply>, tonic::Status>;
+        async fn get_last_output(
+            &self,
+            request: tonic::Request<()>,
+        ) -> Result<tonic::Response<super::LastOutputReply>, tonic::Status>;
         async fn emit_dkg_task(
             &self,
             request: tonic::Request<()>,
         ) -> Result<tonic::Response<super::DkgTaskReply>, tonic::Status>;
+        async fn emit_signature_task(
+            &self,
+            request: tonic::Request<()>,
+        ) -> Result<tonic::Response<super::SignatureTaskReply>, tonic::Status>;
+        async fn get_signature_task_completion_state(
+            &self,
+            request: tonic::Request<super::GetSignatureTaskCompletionStateRequest>,
+        ) -> Result<tonic::Response<super::GetSignatureTaskCompletionStateReply>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ViewsServer<T: Views> {
@@ -611,6 +819,34 @@ pub mod views_server {
                     };
                     Box::pin(fut)
                 }
+                "/controller.Views/GetLastOutput" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetLastOutputSvc<T: Views>(pub Arc<T>);
+                    impl<T: Views> tonic::server::UnaryService<()> for GetLastOutputSvc<T> {
+                        type Response = super::LastOutputReply;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<()>) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).get_last_output(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetLastOutputSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 "/controller.Views/EmitDkgTask" => {
                     #[allow(non_camel_case_types)]
                     struct EmitDkgTaskSvc<T: Views>(pub Arc<T>);
@@ -629,6 +865,70 @@ pub mod views_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = EmitDkgTaskSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/controller.Views/EmitSignatureTask" => {
+                    #[allow(non_camel_case_types)]
+                    struct EmitSignatureTaskSvc<T: Views>(pub Arc<T>);
+                    impl<T: Views> tonic::server::UnaryService<()> for EmitSignatureTaskSvc<T> {
+                        type Response = super::SignatureTaskReply;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<()>) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).emit_signature_task(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = EmitSignatureTaskSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/controller.Views/GetSignatureTaskCompletionState" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetSignatureTaskCompletionStateSvc<T: Views>(pub Arc<T>);
+                    impl<T: Views>
+                        tonic::server::UnaryService<super::GetSignatureTaskCompletionStateRequest>
+                        for GetSignatureTaskCompletionStateSvc<T>
+                    {
+                        type Response = super::GetSignatureTaskCompletionStateReply;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetSignatureTaskCompletionStateRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).get_signature_task_completion_state(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetSignatureTaskCompletionStateSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
                             accept_compression_encodings,

--- a/crates/randcast-mock-demo/stub/coordinator.rs
+++ b/crates/randcast-mock-demo/stub/coordinator.rs
@@ -108,7 +108,7 @@ pub mod transactions_client {
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/coordinator.Transactions/publish");
+            let path = http::uri::PathAndQuery::from_static("/coordinator.Transactions/Publish");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
@@ -310,10 +310,10 @@ pub mod transactions_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
-                "/coordinator.Transactions/publish" => {
+                "/coordinator.Transactions/Publish" => {
                     #[allow(non_camel_case_types)]
-                    struct publishSvc<T: Transactions>(pub Arc<T>);
-                    impl<T: Transactions> tonic::server::UnaryService<super::PublishRequest> for publishSvc<T> {
+                    struct PublishSvc<T: Transactions>(pub Arc<T>);
+                    impl<T: Transactions> tonic::server::UnaryService<super::PublishRequest> for PublishSvc<T> {
                         type Response = ();
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
@@ -330,7 +330,7 @@ pub mod transactions_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
-                        let method = publishSvc(inner);
+                        let method = PublishSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
                             accept_compression_encodings,


### PR DESCRIPTION
changes:
feature: add message concatenation for user randomness request
feature: unify member index start from 0
feature: add BLSCore of node to handle BLS process
feature: add BLSTasksQueue and SignatureResultCache
feature: add BLSTaskListener and SignatureAggregationListener
feature: add flow control and abort signal listener for all monitors
feature: add bls rpc proto and implementation
feature: add committer service rpc proto and implementation
feature: share node rpc endpoint during dkg process privately
feature: add some retry as well as fail handling on listeners
feature: add an user client bin to test controller instructions
improvement: refactor StartingGroupingListener and EndGroupingListener
improvement: get rpc endpoint param by command line and caching
improvement: rename and refactor several types and apis
bug fix: fix disorder of participants in coordinator.start()

TODO: task emitting synchronization, don't request too fast for the current demo

How to run dkg-bls demo:(server ip and port can be changed)
controller-server:
$ cargo run --bin controller-server "[::1]:50052"

node-client:
$ cargo run --bin node-client 0x123 "[::1]:50060" "[::1]:50052"
$ cargo run --bin node-client 0x456 "[::1]:50061" "[::1]:50052"
$ cargo run --bin node-client 0x789 "[::1]:50062" "[::1]:50052"

user-client:
$ cargo run --bin user-client 0x111 "[::1]:50052" request
$ cargo run --bin user-client 0x111 "[::1]:50052" last_output